### PR TITLE
Phant: make object consistent if created with jsonPath or not

### DIFF
--- a/phant/__init__.py
+++ b/phant/__init__.py
@@ -38,7 +38,12 @@ class Phant(object):
         self.title = title
         self._encoder = encoder
         if jsonPath:
+            self._baseUrl = baseUrl
             self._jsonKeys = json.load(open(jsonPath))
+            self.publicKey = self._jsonKeys['publicKey']
+            self.privateKey = self._jsonKeys['privateKey']
+            self.deleteKey = self._jsonKeys['deleteKey']
+            self.title = self._jsonKeys['title']
         else:
             self._baseUrl = baseUrl
             self._jsonKeys = {


### PR DESCRIPTION
I noticed when I was trying to use this library, that if I instantiated Phant() using a JSON file, some things were inconsistent after object was created.

For example:
- `p.title` was set to `None`.
- `p.fields` was generating an exception about private key not being set, even though it was present in the JSON file.

I made this PR to make it so that object `__init__`, if invoked using `jsonPath`, had additional attributes defined to make it consistent with the non-`jsonPath` approach.
