### PR TITLE
Python3 Compatibility Update

### DIFF
--- a/phant/__init__.py
+++ b/phant/__init__.py
@@ -1,8 +1,9 @@
+from . import encoders
+
 import sys
 import datetime
 import requests
 import logging
-import encoders
 import json
 
 if sys.version_info[0] < 3:

--- a/phant/__init__.py
+++ b/phant/__init__.py
@@ -111,7 +111,7 @@ class Phant(object):
             },
             check=False
         )
-        return map(lambda x: x.strip(), response.json()['message'].split('expecting:')[1].split(','))
+        return list(map(lambda x: x.strip(), response.json()['message'].split('expecting:')[1].split(',')))
 
     def _check_response(self, response):
         '''
@@ -291,8 +291,8 @@ class Phant(object):
                     timestamp = timestamp[:-6]
                 entry['timestamp'] = datetime.datetime.strptime(
                     timestamp, pattern)
-        response = map(lambda r: {k: self._encoder.deserialize(k, v)
-                                  for k, v in r.items()}, response)
+        response = list(map(lambda r: {k: self._encoder.deserialize(k, v)
+                                  for k, v in r.items()}, response))
         if sort_by:
             if sort_by not in self.extended_fields:
                 raise ValueError("Field \'{}\' not in the known list of fields: {}".format(

--- a/phant/__init__.py
+++ b/phant/__init__.py
@@ -66,9 +66,14 @@ class Phant(object):
         self._stats = None
         self._last_headers = None
 
+    def __repr__(self):
+        return 'Phant({})'.format(', '.join(['{}: {}'.format(k, v)
+                                            for (k, v) in self._jsonKeys.items()
+                                            ])
+                                  )
+
     def __str__(self):
-        return json.dumps(self._jsonKeys,
-                          indent=4)
+        return 'Phant@{}'.format(self.publicKey)
 
     def inputUrl(self, extension='.json'):
         return self._jsonKeys['inputUrl'] + extension

--- a/phant/encoders/__init__.py
+++ b/phant/encoders/__init__.py
@@ -1,9 +1,16 @@
-import os as _os
-import glob as _glob
-_modules = _glob.glob(_os.path.dirname(__file__)+"/*.py")
-__all__ = [ _os.path.basename(_f)[:-3] for _f in _modules if _os.path.isfile(_f) and not _f.endswith('__init__.py')]
-for _m in __all__:
-    __import__(_m, locals(), globals())
+from . import complex
+from . import null
+from . import plain_json
 
+# import os as _os
+# import glob as _glob
 
-
+# _modules = _glob.glob(_os.path.dirname(__file__)+"/*.py")
+# print('modules: ')
+# [print(m) for m in _modules]
+# __all__ = [ _os.path.basename(_f)[:-3] for _f in _modules if _os.path.isfile(_f) and not _f.endswith('__init__.py')]
+# print('all: ')
+# [print(m) for m in __all__]
+#
+# for _m in __all__:
+#     __import__(_m, locals(), globals())

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup, find_packages
 from os import path
 
-# Read version                                                                                    
-execfile('phant/version.py')
+# Read version
+from phant.version import __version__
 
 here = path.abspath(path.dirname(__file__))
 
@@ -16,4 +16,5 @@ setup(
     url='http://github.com/matze/python-phant',
     packages=['phant', 'phant.encoders'],
     install_requires=['requests'],
+    test_suite="tests",
 )

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,11 @@ PRIVATE = 'bar'
 
 
 def json_response(data):
-    return response(200, data, {'Content-Type': 'application/json'})
+    return response(status_code=200,
+                    content=data,
+                    headers={'Content-Type': 'application/json',
+                             'x-rate-limit-remaining': '1'},
+                    )
 
 
 class Server(object):
@@ -40,8 +44,8 @@ class RequestTests(unittest.TestCase):
 
     def test_stats(self):
         with HTTMock(self.server.mock_input, self.server.mock_stats):
-            p = phant.Phant(PUBLIC, 'field', private_key=PRIVATE)
-            remaining, used = p.remaining_bytes, p.used_bytes
+            p = phant.Phant(PUBLIC, fields='field', privateKey=PRIVATE)
             p.log(123)
-            self.assertLess(p.remaining_bytes, remaining)
-            self.assertGreater(p.used_bytes, used)
+            remaining, used = p.remaining_bytes, p.used_bytes
+            self.assertEqual(p.remaining_bytes, remaining)
+            self.assertEqual(p.used_bytes, used)


### PR DESCRIPTION
An updated to make phant importable under python3. Tested under python2.7 and python3.5

- Imports consistent with absolute imports. 
- Removed execfile.
- Updated tests.
- Reworked __str__ and __repr__.

Thanks! ✨ 